### PR TITLE
fix(stack-limiter): fix compilation on minimum supported version of rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwasm-instrument"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.65.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/src/stack_limiter/mod.rs
+++ b/src/stack_limiter/mod.rs
@@ -11,7 +11,7 @@ use parity_wasm::{
 mod max_height;
 mod thunk;
 
-struct Context {
+pub(crate) struct Context {
 	stack_height_global_idx: u32,
 	func_stack_costs: Vec<u32>,
 	stack_limit: u32,

--- a/src/stack_limiter/thunk.rs
+++ b/src/stack_limiter/thunk.rs
@@ -17,7 +17,7 @@ struct Thunk {
 	idx: Option<u32>,
 }
 
-pub fn generate_thunks<I: IntoIterator<Item = Instruction>>(
+pub(crate) fn generate_thunks<I: IntoIterator<Item = Instruction>>(
 	ctx: &mut Context,
 	module: elements::Module,
 	injection_fn: impl Fn(&FunctionType) -> I,


### PR DESCRIPTION
I missed this in previous PR